### PR TITLE
Add free botton enable/disable function

### DIFF
--- a/tm_driver/include/tm_driver/tm_driver.h
+++ b/tm_driver/include/tm_driver/tm_driver.h
@@ -113,6 +113,9 @@ public:
   bool setRobotStop();
   bool setJointSpdModeoOFF();
   bool setJointSpdModeON();
+  bool FreeBottonEnable();
+  bool FreeBottonDisable();
+
 
   
 

--- a/tm_driver/src/tm_driver.cpp
+++ b/tm_driver/src/tm_driver.cpp
@@ -191,6 +191,16 @@ bool TmDriver::setJointSpdModeoOFF()
     return (interface->sendCommandMsg("nrtservo 0 stop") > 0);
 }
 
+bool TmDriver::FreeBottonEnable()
+{
+    return (interface->sendCommandMsg("cmd50 0 1") > 0);
+}
+
+bool TmDriver::FreeBottonDisable()
+{
+    return (interface->sendCommandMsg("cmd50 0 0") > 0);
+}
+
 bool TmDriver::setMoveJointSpeedabs(const std::vector<double>& q, double blend)
 {
     unsigned int dof = interface->stateRT->getDOF();


### PR DESCRIPTION
If the free botton pressed under joint velocity control mode,
tm5 will move with infinity speed and cause controller to lock
the motors on the robot.
By disabling the free-botton under joint speed mode could prevent
this happened and enable free-botton when you need to use.